### PR TITLE
Bring back MAM_0 into namespaces

### DIFF
--- a/lib/namespaces.js
+++ b/lib/namespaces.js
@@ -272,6 +272,7 @@ module.exports = {
 
 // XEP-0313
     MAM_TMP: 'urn:xmpp:mam:tmp',
+    MAM_0: 'urn:xmpp:mam:0',
     MAM_1: 'urn:xmpp:mam:1',
     MAM_2: 'urn:xmpp:mam:2',
 


### PR DESCRIPTION
I think some are still using it and it causes `NS.MAM_0` in jxt-xmpp (https://github.com/otalk/jxt-xmpp/blob/master/src/mam.js) to be `undefined`