### PR TITLE
updated namespace definition

### DIFF
--- a/lib/namespaces.js
+++ b/lib/namespaces.js
@@ -311,7 +311,7 @@ module.exports = {
     DTLS_SCTP_1: 'urn:xmpp:jingle:transports:dtls-sctp:1',
 
 // XEP-0352
-    CSI: 'urn:xmpp:csi',
+    CSI: 'urn:xmpp:csi:0',
 
 // XEP-0353
     JINGLE_MSG_INITIATE_0: 'urn:xmpp:jingle:jingle-message:0',


### PR DESCRIPTION
Hi,
after wondering for some thime why CSI was not working in our client using stanta.io, I found that it uses an outdated namespace definition. Hence I created this MR...